### PR TITLE
Add Rails 3.2 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .idea/*
 *.gem
-*.gemspec
 .rvmrc
 pkg/*
 test/database.test

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "http://rubygems.org"
+
+# Specify your gem's dependencies in acts-as-dag.gemspec
+gemspec

--- a/acts-as-dag.gemspec
+++ b/acts-as-dag.gemspec
@@ -1,0 +1,24 @@
+# -*- encoding: utf-8 -*-
+$:.push File.expand_path("../lib", __FILE__)
+require "acts-as-dag/version"
+
+Gem::Specification.new do |s|
+  s.name        = "acts-as-dag"
+  s.version     = Acts::As::Dag::VERSION
+  s.authors     = ['Matthew Leventi', 'Robert Schmitt']
+  s.email       = ["resgraph@cox.net"]
+  s.homepage    = 'https://github.com/resgraph/acts-as-dag'
+  s.summary     = %q{Directed Acyclic Graph hierarchy for Rail's ActiveRecord model}
+  s.description = %q{Directed Acyclic Graph hierarchy for Rail's ActiveRecord model}
+
+  s.rubyforge_project = "acts-as-dag"
+
+  s.files         = `git ls-files`.split("\n")
+  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.require_paths = ["lib"]
+
+  # specify any dependencies here; for example:
+  # s.add_development_dependency "rspec"
+  # s.add_runtime_dependency "rest-client"
+end

--- a/lib/acts-as-dag/version.rb
+++ b/lib/acts-as-dag/version.rb
@@ -1,0 +1,7 @@
+module Acts
+  module As
+    module Dag
+      VERSION = "2.5.7"
+    end
+  end
+end

--- a/lib/dag/dag.rb
+++ b/lib/dag/dag.rb
@@ -19,8 +19,8 @@ module Dag
       end
     end
 
-    write_inheritable_attribute :acts_as_dag_options, conf
-    class_inheritable_reader :acts_as_dag_options
+    class_attribute :acts_as_dag_options, :instance_writer => false
+    self.acts_as_dag_options = conf
 
     extend Columns
     include Columns


### PR DESCRIPTION
Simple change to add rails 3.2 support.  Also adds a gemfile and gemspec to make it easier to publish the gem as well as use it locally.
