### PR TITLE
Fix failing validation when saving a new node object with associated parents

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -137,16 +137,12 @@ Several class methods get added to the link model to make it easier to find and 
     
     #Finds a link or returns nil
     self.find_link(ancestor,descendant)
-    #Returns true if a link exists
-    self.connected?(ancestor,descendant)
     
     #Creates an edge between an ancestor and descendant
     self.create_edge(ancestor,descendant)
-    self.connect(ancestor,descendant)
     
     #Creates an edge using save! between an ancestor and descendant
     self.create_edge!(ancestor,descendant)
-    self.connect!(ancestor,descendant)
     
     #Builds an edge between an ancestor and descendant, returning an unsaved edge
     self.build_edge(ancestor,descendant)

--- a/lib/dag/standard.rb
+++ b/lib/dag/standard.rb
@@ -12,6 +12,10 @@ module Dag
         self.id == other.id
       end
 
+      def nil?
+        self.id.nil?
+      end
+
       #Factory Construction method that creates an endpoint from a model
       def self.from_resource(resource)
         self.new(resource.id)

--- a/lib/dag/validators.rb
+++ b/lib/dag/validators.rb
@@ -39,7 +39,6 @@ module Dag
   class UpdateCorrectnessValidator < ActiveModel::Validator
 
     def validate(record)
-      record.errors[:base] << "No changes" unless record.changed?
       record.errors[:base] << "Do not manually change the count value" if manual_change(record)
       record.errors[:base] << "Cannot make a direct link with count 1 indirect" if direct_indirect(record)
     end

--- a/test/dag_test.rb
+++ b/test/dag_test.rb
@@ -122,7 +122,7 @@ class DagTest < Minitest::Test
 
   #Brings down database
   def teardown
-    ActiveRecord::Base.connection.tables.each do |table|
+    ActiveRecord::Base.connection.data_sources.each do |table|
       ActiveRecord::Base.connection.drop_table(table)
     end
   end


### PR DESCRIPTION
This PR resolves issue #20.
