### PR TITLE
Use #data_sources instead of #tables

### DIFF
--- a/test/dag_test.rb
+++ b/test/dag_test.rb
@@ -122,7 +122,7 @@ class DagTest < Minitest::Test
 
   #Brings down database
   def teardown
-    ActiveRecord::Base.connection.tables.each do |table|
+    ActiveRecord::Base.connection.data_sources.each do |table|
       ActiveRecord::Base.connection.drop_table(table)
     end
   end


### PR DESCRIPTION
Latest ActiveRecord (5.0.0) says:

DEPRECATION WARNING: #tables currently returns both tables and views.
This behavior is deprecated and will be changed with Rails 5.1 to only
return tables. Use #data_sources instead.
