### PR TITLE
Fixed Rails 5 deprecation warning

### DIFF
--- a/test/dag_test.rb
+++ b/test/dag_test.rb
@@ -122,7 +122,7 @@ class DagTest < Minitest::Test
 
   #Brings down database
   def teardown
-    ActiveRecord::Base.connection.tables.each do |table|
+    ActiveRecord::Base.connection.data_sources.each do |table|
       ActiveRecord::Base.connection.drop_table(table)
     end
   end


### PR DESCRIPTION
Fixes deprecation warning when running tests under rails 5.

Previously `tables` was returning all tables and views, but starting with 5.1 it will return only tables, and `data_sources` is used to match the old `tables` functionality

(Other than that, everything seems to be working fine with rails 5)
