### PR TITLE
Fixed issue where directly setting parents on create failed

### DIFF
--- a/lib/dag/edges.rb
+++ b/lib/dag/edges.rb
@@ -43,6 +43,8 @@ module Dag
       if link.nil?
         edge = self.build_edge(ancestor, descendant)
         return edge.save
+      elsif link.direct?
+        return false
       else
         link.make_direct
         return link.save
@@ -56,6 +58,8 @@ module Dag
         edge = self.build_edge(ancestor, descendant)
         edge.save!
         edge
+      elsif link.direct?
+        raise ActiveRecord::RecordInvalid
       else
         link.make_direct
         link.save!

--- a/lib/dag/validators.rb
+++ b/lib/dag/validators.rb
@@ -39,7 +39,6 @@ module Dag
   class UpdateCorrectnessValidator < ActiveModel::Validator
 
     def validate(record)
-      record.errors[:base] << "No changes" unless record.changed?
       record.errors[:base] << "Do not manually change the count value" if manual_change(record)
       record.errors[:base] << "Cannot make a direct link with count 1 indirect" if direct_indirect(record)
     end

--- a/test/dag_test.rb
+++ b/test/dag_test.rb
@@ -402,15 +402,6 @@ class DagTest < Minitest::Test
     assert_raises(ActiveRecord::RecordInvalid) { e.save! }
   end
 
-  #Tests that nochanges fails save and save!
-  def test_validation_on_update_no_change_catch
-    a = Node.create!
-    b = Node.create!
-    e = Default.create_edge!(a, b)
-    assert !e.save
-    assert_raises(ActiveRecord::RecordInvalid) { e.save! }
-  end
-
   #Tests that destroyable? works as required
   def tests_destroyable
     a = Node.create!
@@ -606,6 +597,11 @@ class DagTest < Minitest::Test
     b.parents << a
     e = Default.find_link(a, b)
     assert !e.nil?
+  end
+
+  def test_create_with_parents
+    a = Node.create!
+    Node.create!(parent_ids: [a.id])
   end
 
   def test_has_many_parents_build_assign


### PR DESCRIPTION
Rails double-saves the join table when directly creating a has-many-through.

Added `test_create_with_parents` to demonstrate the issue.

It seems like the "No changes" error was there just to prevent `create_edge` from succeeding when an edge already existed. So I moved the logic to the `create_edge` and `create_edge!` methods instead of universally preventing double saves.
